### PR TITLE
Fix for HasDiscriminator

### DIFF
--- a/BuberDinner-dotnet8/BuberDinner.Domain/Common/Models/AggregateRoot.cs
+++ b/BuberDinner-dotnet8/BuberDinner.Domain/Common/Models/AggregateRoot.cs
@@ -3,7 +3,7 @@ namespace BuberDinner.Domain.Common.Models;
 public abstract class AggregateRoot<TId, TIdType> : Entity<TId>
     where TId : AggregateRootId<TIdType>
 {
-    public new AggregateRootId<TIdType> Id { get; protected set; }
+    public override TId Id { get; protected set; }
 
     protected AggregateRoot(TId id)
     {

--- a/BuberDinner-dotnet8/BuberDinner.Domain/Common/Models/Entity.cs
+++ b/BuberDinner-dotnet8/BuberDinner.Domain/Common/Models/Entity.cs
@@ -3,7 +3,7 @@ namespace BuberDinner.Domain.Common.Models;
 public abstract class Entity<TId> : IEquatable<Entity<TId>>
     where TId : ValueObject
 {
-    public TId Id { get; protected set; }
+    public virtual TId Id { get; protected set; }
 
     protected Entity(TId id)
     {


### PR DESCRIPTION
Problem was that you have two different `Id` properties - and the one in `AggregateRoot<TId, TIdType>` uses the `new` keyword to hide the `Id` property from the base class.